### PR TITLE
[ST-660] 백엔드 FCM 메시지 포맷 반영

### DIFF
--- a/src/offer/offer.service.ts
+++ b/src/offer/offer.service.ts
@@ -1,7 +1,7 @@
 import { ChattingRepository } from '../chatting/chatting.repository';
 import { QuestionRepository } from '../question/question.repository';
 import { Fail, Success } from '../response';
-import { SocketGateway } from '../socket/socket.gateway';
+import { SocketRepository } from '../socket/socket.repository';
 import { TutoringRepository } from '../tutoring/tutoring.repository';
 import { UserRepository } from '../user/user.repository';
 import { OfferRepository } from './offer.repository';
@@ -15,7 +15,7 @@ export class OfferService {
     private readonly chattingRepository: ChattingRepository,
     private readonly questionRepository: QuestionRepository,
     private readonly tutoringRepository: TutoringRepository,
-    private readonly socketGateway: SocketGateway,
+    private readonly socketRepository: SocketRepository,
   ) {}
 
   async append(userId: string, questionId: string) {
@@ -54,14 +54,14 @@ export class OfferService {
         text: '안녕하세요 선생님! 언제 수업 가능하신가요?',
       };
 
-      await this.socketGateway.sendMessageToBothUser(
+      await this.socketRepository.sendMessageToBothUser(
         studentId,
         userId,
         chatRoomId,
         'problem-image',
         JSON.stringify(problemMessage),
       );
-      await this.socketGateway.sendMessageToBothUser(
+      await this.socketRepository.sendMessageToBothUser(
         studentId,
         userId,
         chatRoomId,
@@ -136,7 +136,7 @@ export class OfferService {
         startTime: startTime.toISOString(),
       };
 
-      await this.socketGateway.sendMessageToBothUser(
+      await this.socketRepository.sendMessageToBothUser(
         userId,
         chatting.teacherId,
         chattingId,
@@ -155,7 +155,7 @@ export class OfferService {
               questionId,
               offerTeacherId,
             );
-          await this.socketGateway.sendMessageToBothUser(
+          await this.socketRepository.sendMessageToBothUser(
             userId,
             offerTeacherId,
             teacherChatId,

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -1,6 +1,6 @@
 import { ChattingRepository } from '../chatting/chatting.repository';
 import { Fail, Success } from '../response';
-import { SocketGateway } from '../socket/socket.gateway';
+import { SocketRepository } from '../socket/socket.repository';
 import { UserRepository } from '../user/user.repository';
 import {
   CreateNormalQuestionDto,
@@ -17,7 +17,7 @@ export class QuestionService {
     private readonly questionRepository: QuestionRepository,
     private readonly chattingRepository: ChattingRepository,
     private readonly userRepository: UserRepository,
-    private readonly socketGateway: SocketGateway,
+    private readonly socketRepository: SocketRepository,
   ) {}
 
   /**
@@ -97,14 +97,14 @@ export class QuestionService {
         startDateTime: createQuestionDto.requestTutoringStartTime.toISOString(),
       };
 
-      await this.socketGateway.sendMessageToBothUser(
+      await this.socketRepository.sendMessageToBothUser(
         userId,
         teacherId,
         chatRoomId,
         'problem-image',
         JSON.stringify(problemMessage),
       );
-      await this.socketGateway.sendMessageToBothUser(
+      await this.socketRepository.sendMessageToBothUser(
         userId,
         teacherId,
         chatRoomId,

--- a/src/socket/socket.module.ts
+++ b/src/socket/socket.module.ts
@@ -17,6 +17,6 @@ import { Module } from '@nestjs/common';
     redisSubProvider,
     UserRepository,
   ],
-  exports: [SocketRepository, SocketGateway],
+  exports: [SocketRepository],
 })
 export class SocketModule {}

--- a/src/socket/socket.repository.ts
+++ b/src/socket/socket.repository.ts
@@ -66,7 +66,7 @@ export class SocketRepository {
   }
 
   /**
-   * 다른 사용자에게 메시지를 전송하는 메소드
+   * 다른 사용자에게 메시지를 전송하는 메소드 , 연결된 소켓이 있으면 소켓 전송, 레디스에 브로드캐스트, DynamoDB에 저장
    * @param senderId 메시지를 보내는 사용자의 ID
    * @param receiverId 메시지를 받는 사용자의 ID
    * @param chattingId 메시지를 보내는 채팅방의 ID
@@ -89,8 +89,6 @@ export class SocketRepository {
     const receiverSocketId = await this.redisRepository.getSocketId(receiverId);
     if (receiverSocketId != null) {
       this.sendMessageToSocketClient(receiverSocketId, chattingId, message);
-    } else {
-      //FCM 메시지 보내기
     }
 
     // 레디스 브로드캐스트
@@ -125,15 +123,18 @@ export class SocketRepository {
 
     if (receiverSocketId != null) {
       this.sendMessageToSocketClient(receiverSocketId, chattingId, message);
-    } else {
-      console.log('receiver is not online', receiverId);
-      //TODO: FCM 메시지 보내기
     }
+    await this.sendPushMessageToUser(
+      senderId,
+      receiverId,
+      chattingId,
+      format,
+      body,
+    );
+
     const senderSocketId = await this.redisRepository.getSocketId(senderId);
     if (senderSocketId != null) {
       this.sendMessageToSocketClient(senderSocketId, chattingId, message);
-    } else {
-      console.log('sender is not online', senderId);
     }
 
     // 레디스 브로드캐스트

--- a/src/tutoring/tutoring.service.ts
+++ b/src/tutoring/tutoring.service.ts
@@ -2,7 +2,7 @@ import { AgoraService } from '../agora/agora.service';
 import { ChattingRepository } from '../chatting/chatting.repository';
 import { QuestionRepository } from '../question/question.repository';
 import { Fail, Success } from '../response';
-import { SocketGateway } from '../socket/socket.gateway';
+import { SocketRepository } from '../socket/socket.repository';
 import { UserRepository } from '../user/user.repository';
 import { ClassroomInfo, TutoringInfo } from './entities/tutoring.entity';
 import { TutoringRepository } from './tutoring.repository';
@@ -14,7 +14,7 @@ export class TutoringService {
     private readonly tutoringRepository: TutoringRepository,
     private readonly questionRepository: QuestionRepository,
     private readonly agoraService: AgoraService,
-    private readonly socketGateway: SocketGateway,
+    private readonly socketRepository: SocketRepository,
     private readonly userRepository: UserRepository,
     private readonly chattingRepository: ChattingRepository,
   ) {}
@@ -67,7 +67,7 @@ export class TutoringService {
           question.selectedTeacherId,
         );
 
-      await this.socketGateway.sendMessageToBothUser(
+      await this.socketRepository.sendMessageToBothUser(
         question.selectedTeacherId,
         question.studentId,
         chatRoomId,
@@ -153,7 +153,7 @@ export class TutoringService {
 
       await this.questionRepository.changeStatus(chattingId, 'declined');
 
-      await this.socketGateway.sendMessageToBothUser(
+      await this.socketRepository.sendMessageToBothUser(
         chatRoomInfo.teacherId,
         chatRoomInfo.studentId,
         chattingId,


### PR DESCRIPTION
## 업데이트 유형
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## 업데이트 개요
* Fix #71 

## 업데이트 요약
- FCM 메시지 포맷 반영
푸시 메시지 전송시 아래 포맷 반영
소켓 메시지와 동일하나, `type` 추가 (소켓에도 추가해야할지도?)
```json
"data": {
  "chattingId": "채팅방 id",
  "sender": "송산자 id",
  "format": "메시지 포맷",
  "body": "메시지 본문",
  "createdAt": "보낸 시각",
  "type": "메시지 타입 (chatting, announce etc)",
},

```
- socket - gateway / repository 분리
단순 메시지 전송 메소드 socket.repository로 이동
question, offer, tutoring에서 socket.gateway가 아닌 socket.repository를 참조하도록 수정

## 해결한 문제
소켓&FCM 메시지 포맷 얼추 통일
다른 모듈에서 socket.gateway를 참조하는 부분 수정

## 미해결 문제


## 테스트
- [ ] 유닛 테스트
- [x] 빌드 테스트 (통합 테스트)
- [x] 기타 유효성 테스트

## 수정 사항 진단
- [x] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [x] 코드에 대한 자체 리뷰를 수행했습니다.
- [x] 변경 내역에 대해 주석을 작성했습니다.
- [ ] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 수정 사항, 이슈에 대한 테스트 코드를 추가했습니다.
- [x] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
