### PR TITLE
[ST-684] 과외 종료시 채팅방에 메시지 전송. 과외 종료되면 토큰 생성 안해줌.

### DIFF
--- a/src/tutoring/tutoring.service.ts
+++ b/src/tutoring/tutoring.service.ts
@@ -108,8 +108,11 @@ export class TutoringService {
         return new Fail('해당 과외 정보가 없습니다.');
       }
 
-      if (userInfo.role == 'student' && tutoring.status != 'going') {
+      if (userInfo.role == 'student' && tutoring.status == 'reserved') {
         return new Fail('수업 시작 전입니다.');
+      }
+      if (userInfo.role == 'student' && tutoring.status == 'finished') {
+        return new Fail('수업이 종료되었습니다.');
       }
       const whiteBoardToken = await this.agoraService.makeWhiteBoardToken(
         tutoring.whiteBoardUUID,
@@ -141,9 +144,6 @@ export class TutoringService {
         return new Fail('해당 과외 정보를 볼 수 없습니다.');
       }
       const tutoring = await this.tutoringRepository.get(question.tutoringId);
-      if (tutoring.status == 'finished') {
-        return new Fail('과외가 종료되었습니다.');
-      }
       const tutoringInfo: TutoringInfo = {
         id: tutoring.id,
         questionId: tutoring.questionId,

--- a/src/tutoring/tutoring.service.ts
+++ b/src/tutoring/tutoring.service.ts
@@ -30,9 +30,24 @@ export class TutoringService {
         'finished',
       );
 
+      const finishMessage = {
+        startAt: tutoring.startedAt,
+        endAt: tutoring.endedAt,
+      };
+
+      await this.socketRepository.sendMessageToBothUser(
+        tutoring.teacherId,
+        tutoring.studentId,
+        tutoring.questionId,
+        'tutoring-finished',
+        JSON.stringify(finishMessage),
+      );
+
+      //TODO : 과외 종료시, 과외에 참여한 학생과 선생님의 포인트를 수정하는 로직 추가
+
       return new Success('과외가 종료되었습니다.', { tutoringId });
     } catch (error) {
-      return new Fail(error.message);
+      return new Fail('과외를 종료할 수 없습니다.');
     }
   }
 
@@ -126,6 +141,9 @@ export class TutoringService {
         return new Fail('해당 과외 정보를 볼 수 없습니다.');
       }
       const tutoring = await this.tutoringRepository.get(question.tutoringId);
+      if (tutoring.status == 'finished') {
+        return new Fail('과외가 종료되었습니다.');
+      }
       const tutoringInfo: TutoringInfo = {
         id: tutoring.id,
         questionId: tutoring.questionId,
@@ -174,6 +192,10 @@ export class TutoringService {
       if (tutoring.teacherId != teacherId) {
         return new Fail('해당 과외를 진행할 수 없습니다.');
       }
+      if (tutoring.status == 'finished') {
+        return new Fail('이미 종료된 과외입니다.');
+      }
+
       await this.tutoringRepository.startTutoring(tutoringId);
 
       return await this.classroomInfo(tutoring.id, teacherId);


### PR DESCRIPTION
## 업데이트 유형
- [ ] Hot Fix
- [ ] Release
- [ ] Develop
- [ ] Others

## 업데이트 개요
* Fix # (issue)
* Feature # (issue)  
[여기에 PR 한줄 요약 작성, 대상 이슈번호 작성.]
[과외 종료시 채팅방에 메시지 전송. 과외 종료되면 토큰 생성 안해줌.](https://github.com/amicably-until-the-end/ShortTutoring_API/commit/7e4ad8a2eedfb30e643008ed901603ed1eb8f564)

## 업데이트 요약
업데이트 내역 작성

## 해결한 문제
해결한 문제 등 이슈

## 미해결 문제
미해결 이슈, 발견한 이슈

## 테스트
- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [ ] 기타 유효성 테스트

## 수정 사항 진단
- [ ] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [ ] 코드에 대한 자체 리뷰를 수행했습니다.
- [ ] 변경 내역에 대해 주석을 작성했습니다.
- [ ] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 수정 사항, 이슈에 대한 테스트 코드를 추가했습니다.
- [ ] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
